### PR TITLE
Make serialization swappable

### DIFF
--- a/lib/bertrpc.rb
+++ b/lib/bertrpc.rb
@@ -17,4 +17,13 @@ module BERTRPC
   end
 
   VERSION = self.version
+
+  def self.serializer=(serializer)
+    @serializer = serializer
+  end
+  self.serializer = BERT
+
+  def self.serializer
+    @serializer
+  end
 end

--- a/lib/bertrpc/encodes.rb
+++ b/lib/bertrpc/encodes.rb
@@ -12,7 +12,7 @@ module BERTRPC
         when 'noreply'
           nil
         when 'error'
-          error(ruby_response[1].to_s)
+          error(ruby_response[1])
         else
           raise
       end
@@ -21,7 +21,7 @@ module BERTRPC
     def error(err)
       level, code, klass, message, backtrace = err
 
-      case level
+      case level.to_s
         when 'protocol'
           raise ProtocolError.new([code, message], klass, backtrace)
         when 'server'

--- a/lib/bertrpc/encodes.rb
+++ b/lib/bertrpc/encodes.rb
@@ -1,11 +1,11 @@
 module BERTRPC
   module Encodes
     def encode_ruby_request(ruby_request)
-      BERT.encode(ruby_request)
+      BERTRPC.serializer.encode(ruby_request)
     end
 
     def decode_bert_response(bert_response)
-      ruby_response = BERT.decode(bert_response)
+      ruby_response = BERTRPC.serializer.decode(bert_response)
       case ruby_response[0]
         when :reply
           ruby_response[1]

--- a/lib/bertrpc/encodes.rb
+++ b/lib/bertrpc/encodes.rb
@@ -6,13 +6,13 @@ module BERTRPC
 
     def decode_bert_response(bert_response)
       ruby_response = BERTRPC.serializer.decode(bert_response)
-      case ruby_response[0]
-        when :reply
+      case ruby_response[0].to_s
+        when 'reply'
           ruby_response[1]
-        when :noreply
+        when 'noreply'
           nil
-        when :error
-          error(ruby_response[1])
+        when 'error'
+          error(ruby_response[1].to_s)
         else
           raise
       end
@@ -22,13 +22,13 @@ module BERTRPC
       level, code, klass, message, backtrace = err
 
       case level
-        when :protocol
+        when 'protocol'
           raise ProtocolError.new([code, message], klass, backtrace)
-        when :server
+        when 'server'
           raise ServerError.new([code, message], klass, backtrace)
-        when :user
+        when 'user'
           raise UserError.new([code, message], klass, backtrace)
-        when :proxy
+        when 'proxy'
           raise ProxyError.new([code, message], klass, backtrace)
         else
           raise


### PR DESCRIPTION
This makes it so BERT serialization can potentially be swapped out with something else.
