### PR TITLE
Remove use of gemcutter.org from installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ exemplary.
 Installation
 ------------
 
-    $ gem install bertrpc -s http://gemcutter.org
+    $ gem install bertrpc
 
 
 Examples


### PR DESCRIPTION
It seems gemcutter.org merged with rubygems.org.
